### PR TITLE
TEMPFIX for bug hiding images in user post page

### DIFF
--- a/peep/templates/home.html
+++ b/peep/templates/home.html
@@ -12,7 +12,7 @@
 
 			{% if post.image_file %}
 			<p class="article-pic">
-				<img height='300' src="{{ url_for('static', filename='user_uploads/' + post.image_file) }}" alt="">
+				<img height='300' src="{{ url_for('static', filename='post_pics/' + post.image_file) }}" alt="">
 			</p>
 			{% endif %}
 

--- a/peep/templates/post.html
+++ b/peep/templates/post.html
@@ -16,7 +16,7 @@
 		<h2 class="article-title">{{ post.title }}</h2>
 		{% if post.image_file %}
 		<p class="article-pic">
-			<img height='300' src="{{ url_for('static', filename='user_uploads/' + post.image_file) }}" alt="">
+			<img height='300' src="{{ url_for('static', filename='post_pics/' + post.image_file) }}" alt="">
 		</p>
 		{% endif %}
 		<p class="article-content">{{ post.content }}</p>

--- a/peep/templates/user_posts.html
+++ b/peep/templates/user_posts.html
@@ -10,7 +10,11 @@
               <small class="text-muted">{{ post.date_posted.strftime('%Y-%m-%d') }}</small>
             </div>
             <h2><a class="article-title" href="{{ url_for('posts.post', post_id=post.id) }}">{{ post.title }}</a></h2>
-			<p class="article-pic"><img width='300' height='300' src="{{ post.image_file }}" alt=""></p>
+			{% if post.image_file %}
+			<p class="article-pic">
+				<img height='300' src="{{ url_for('static', filename='post_pics/' + post.image_file) }}" alt="">
+			</p>
+			{% endif %}
             <p class="article-content">{{ post.content }}</p>
           </div>
         </article>


### PR DESCRIPTION
Made it so all images uploaded via image upload page or from within a post are saved in user uploads. In future, we'll want to differentiate so deleting one doesn't delete the other (currently: adding image in post adds it to "my images" page. If user then deletes that image from "my images" page then it will leave empty space in the post where it should be displayed).