### PR TITLE
Post carousel refactor

### DIFF
--- a/peep/templates/home.html
+++ b/peep/templates/home.html
@@ -13,15 +13,15 @@
 
 			<p class="article-content">{{ post.content }}</p>
 			
-			{% if post_images[outer_loop.index0]|length %}
+			{% if post_images[outer_loop.index0]|length > 1 %}
 			<!-- post pic carousel -->
-			<div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
+			<div id="carousel{{ outer_loop.index }}" class="carousel slide" data-ride="carousel">
 				<ol class="carousel-indicators">
 				{% for image in post_images[outer_loop.index0] %}
 					{% if loop.index == 1 %}
-					<li data-target="#carouselExampleIndicators" data-slide-to="{{loop.index}}" class="active"></li>
+					<li data-target="#carousel{{ outer_loop.index }}" data-slide-to="{{loop.index}}" class="active"></li>
 					{% else %}
-					<li data-target="#carouselExampleIndicators" data-slide-to="{{loop.index}}"></li>
+					<li data-target="#carousel{{ outer_loop.index }}" data-slide-to="{{loop.index}}"></li>
 					{% endif %}
 				{% endfor %}
 				</ol>
@@ -38,15 +38,20 @@
 					{% endif %}
 					{% endfor %}
 				</div>
-				<a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">
+				<a class="carousel-control-prev" href="#carousel{{ outer_loop.index }}" role="button" data-slide="prev">
 					<span class="carousel-control-prev-icon" aria-hidden="true"></span>
 					<span class="sr-only">Previous</span>
 				</a>
-				<a class="carousel-control-next" href="#carouselExampleIndicators" role="button" data-slide="next">
+				<a class="carousel-control-next" href="#carousel{{ outer_loop.index }}" role="button" data-slide="next">
 					<span class="carousel-control-next-icon" aria-hidden="true"></span>
 					<span class="sr-only">Next</span>
 				</a>
 			</div>
+			{% elif post_images[outer_loop.index0]|length == 1 %}
+			<img
+				class="d-block w-100"
+				src="{{ url_for('static', filename='post_pics/' + post_images[outer_loop.index0][0].image_file) }}"
+				alt="{{ post_images[outer_loop.index0][0].image_file }}">
 			{% endif %}
 
 			<!-- buttons -->

--- a/peep/templates/post.html
+++ b/peep/templates/post.html
@@ -10,15 +10,15 @@
 			<h2 class="article-title">{{ post.title }}</h2>
 			<p class="article-content">{{ post.content }}</p>
 
-			{% if post_images|length %}
+			{% if post_images|length > 1 %}
 			<!-- post pic carousel -->
 			<div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
 				<ol class="carousel-indicators">
 				{% for image in post_images %}
 					{% if loop.index == 1 %}
-					<li data-target="#carouselExampleIndicators" data-slide-to="{{loop.index}}" class="active"></li>
+					<li data-target="#carousel" data-slide-to="{{loop.index}}" class="active"></li>
 					{% else %}
-					<li data-target="#carouselExampleIndicators" data-slide-to="{{loop.index}}"></li>
+					<li data-target="#carousel" data-slide-to="{{loop.index}}"></li>
 					{% endif %}
 				{% endfor %}
 				</ol>
@@ -35,15 +35,17 @@
 					{% endif %}
 					{% endfor %}
 				</div>
-				<a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">
+				<a class="carousel-control-prev" href="#carousel" role="button" data-slide="prev">
 					<span class="carousel-control-prev-icon" aria-hidden="true"></span>
 					<span class="sr-only">Previous</span>
 				</a>
-				<a class="carousel-control-next" href="#carouselExampleIndicators" role="button" data-slide="next">
+				<a class="carousel-control-next" href="#carousel" role="button" data-slide="next">
 					<span class="carousel-control-next-icon" aria-hidden="true"></span>
 					<span class="sr-only">Next</span>
 				</a>
 			</div>
+			{% elif post_images|length == 1 %}
+			<img class="d-block w-100" src="{{ url_for('static', filename='post_pics/' + post_images[0].image_file) }}" alt="{{ post_images[0].image_file }}">
 			{% endif %}
 	
 			<div class="dropdown">

--- a/peep/templates/user_images.html
+++ b/peep/templates/user_images.html
@@ -5,7 +5,7 @@
 		<div class = "wrapper"> 
 
 			<!-- Image loop -->
-			{% for image in images %}
+			{% for image in images.items %}
 			<div class = 'image-content'>
 				<a href = "{{ url_for('static', filename='user_uploads/' + image.image_file) }}"
 				class = "fancybox" data-fancybox = "gallery1">
@@ -90,6 +90,18 @@
 		{% endfor %}
 		
 	</div>
+
 	<!-- paginate -->
+	{% for page_num in images.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
+		{% if page_num %}
+			{% if images.page == page_num %}
+				<a class="btn btn-info mb-4" href="{{ url_for('users.user_images', username=current_user.username, page=page_num) }}">{{ page_num }}</a>
+			{% else %}
+				<a class="btn btn-outline-info mb-4" href="{{ url_for('users.user_images', username=current_user.username, page=page_num) }}">{{ page_num }}</a>
+			{% endif %}
+		{% else %}
+			...
+		{% endif %}
+	{% endfor %}
 
 {% endblock content %}

--- a/peep/templates/user_images_fav.html
+++ b/peep/templates/user_images_fav.html
@@ -5,7 +5,7 @@
     <div class = "wrapper"> 
 
         <!-- Image loop -->
-        {% for image in images %}
+        {% for image in images.items %}
         <div class = 'image-content'>
             <a href = "{{ url_for('static', filename='user_uploads/' + image.image_file) }}"
                class = "fancybox" data-fancybox = "gallery1">
@@ -88,5 +88,18 @@
 {% endif %}
 {% endfor %}
 </div>
+
+<!-- paginate -->
+{% for page_num in images.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
+	{% if page_num %}
+		{% if images.page == page_num %}
+			<a class="btn btn-info mb-4" href="{{ url_for('users.user_images', username=current_user.username, page=page_num) }}">{{ page_num }}</a>
+		{% else %}
+			<a class="btn btn-outline-info mb-4" href="{{ url_for('users.user_images', username=current_user.username, page=page_num) }}">{{ page_num }}</a>
+		{% endif %}
+	{% else %}
+		...
+	{% endif %}
+{% endfor %}
 
 {% endblock content %}

--- a/peep/templates/user_images_identified.html
+++ b/peep/templates/user_images_identified.html
@@ -5,7 +5,7 @@
     <div class = "wrapper"> 
 
         <!-- Image loop -->
-        {% for image in images %}
+        {% for image in images.items %}
         <div class = 'image-content'>
             <a href = "{{ url_for('static', filename='user_uploads/' + image.image_file) }}"
                class = "fancybox" data-fancybox = "gallery1">
@@ -88,5 +88,18 @@
 {% endif %}
 {% endfor %}
 </div>
+
+<!-- paginate -->
+{% for page_num in images.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
+	{% if page_num %}
+		{% if images.page == page_num %}
+			<a class="btn btn-info mb-4" href="{{ url_for('users.user_images', username=current_user.username, page=page_num) }}">{{ page_num }}</a>
+		{% else %}
+			<a class="btn btn-outline-info mb-4" href="{{ url_for('users.user_images', username=current_user.username, page=page_num) }}">{{ page_num }}</a>
+		{% endif %}
+	{% else %}
+		...
+	{% endif %}
+{% endfor %}
 
 {% endblock content %}

--- a/peep/templates/user_images_training.html
+++ b/peep/templates/user_images_training.html
@@ -5,7 +5,7 @@
     <div class = "wrapper"> 
 
         <!-- Image loop -->
-        {% for image in images %}
+        {% for image in images.items %}
         <div class = 'image-content'>
             <a href = "{{ url_for('static', filename='user_uploads/' + image.image_file) }}"
                class = "fancybox" data-fancybox = "gallery1">
@@ -88,5 +88,18 @@
 {% endif %}
 {% endfor %}
 </div>
+
+<!-- paginate -->
+{% for page_num in images.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
+	{% if page_num %}
+		{% if images.page == page_num %}
+			<a class="btn btn-info mb-4" href="{{ url_for('users.user_images', username=current_user.username, page=page_num) }}">{{ page_num }}</a>
+		{% else %}
+			<a class="btn btn-outline-info mb-4" href="{{ url_for('users.user_images', username=current_user.username, page=page_num) }}">{{ page_num }}</a>
+		{% endif %}
+	{% else %}
+		...
+	{% endif %}
+{% endfor %}
 
 {% endblock content %}

--- a/peep/templates/user_posts.html
+++ b/peep/templates/user_posts.html
@@ -13,15 +13,15 @@
             <h2><a class="article-title" href="{{ url_for('posts.post', post_id=post.id) }}">{{ post.title }}</a></h2>
 			<p class="article-content">{{ post.content }}</p>
 			
-			{% if post_images[outer_loop.index0]|length %}
+			{% if post_images[outer_loop.index0]|length > 1 %}
 			<!-- post pic carousel -->
-			<div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
+			<div id="carousel{{ outer_loop.index }}" class="carousel slide" data-ride="carousel">
 				<ol class="carousel-indicators">
 				{% for image in post_images[outer_loop.index0] %}
 					{% if loop.index == 1 %}
-					<li data-target="#carouselExampleIndicators" data-slide-to="{{loop.index}}" class="active"></li>
+					<li data-target="#carousel{{ outer_loop.index }}" data-slide-to="{{loop.index}}" class="active"></li>
 					{% else %}
-					<li data-target="#carouselExampleIndicators" data-slide-to="{{loop.index}}"></li>
+					<li data-target="#carousel{{ outer_loop.index }}" data-slide-to="{{loop.index}}"></li>
 					{% endif %}
 				{% endfor %}
 				</ol>
@@ -38,15 +38,21 @@
 					{% endif %}
 					{% endfor %}
 				</div>
-				<a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">
+				<a class="carousel-control-prev" href="#carousel{{ outer_loop.index }}" role="button" data-slide="prev">
 					<span class="carousel-control-prev-icon" aria-hidden="true"></span>
 					<span class="sr-only">Previous</span>
 				</a>
-				<a class="carousel-control-next" href="#carouselExampleIndicators" role="button" data-slide="next">
+				<a class="carousel-control-next" href="#carousel{{ outer_loop.index }}" role="button" data-slide="next">
 					<span class="carousel-control-next-icon" aria-hidden="true"></span>
 					<span class="sr-only">Next</span>
 				</a>
 			</div>
+			{% elif post_images[outer_loop.index0]|length == 1 %}
+			<img 
+				class="d-block w-100"
+				src="{{ url_for('static', filename='post_pics/' + post_images[outer_loop.index0][0].image_file) }}"
+				alt="{{ post_images[outer_loop.index0][0].image_file }}"
+			>
 			{% endif %}
 
 			<a class="reply-btn btn" href="{{ url_for('posts.post', post_id=post.id) }}">View Comments</a>

--- a/peep/users/routes.py
+++ b/peep/users/routes.py
@@ -113,11 +113,16 @@ def user_posts(username):
 @users.route('/user/<string:username>/images')
 def user_images(username):
 	user = User.query.filter_by(username=username).first_or_404()
+
 	# users can only view their own images
 	if user != current_user:
 		abort(403)
+
+	# get page, and paginate images
+	page = request.args.get('page', 1, type=int)
 	images = Image.query.filter_by(owner=user)\
-		.order_by(Image.date_uploaded.desc()).all()
+		.order_by(Image.date_uploaded.desc()).paginate(page=page, per_page=9)
+	
 	return render_template('user_images.html', images=images, user=user)
 
 
@@ -127,8 +132,12 @@ def user_images_fav(username):
 	# users can only view their own images
 	if user != current_user:
 		abort(403)
-	images = Image.query.filter_by(owner=user , favorited=True)\
-		.order_by(Image.date_uploaded.desc()).all()
+	
+	# get page, and paginate images
+	page = request.args.get('page', 1, type=int)
+	images = Image.query.filter_by(owner=user, favorited=True)\
+		.order_by(Image.date_uploaded.desc()).paginate(page=page, per_page=9)
+	
 	return render_template('user_images_fav.html', images=images, user=user)
 
 
@@ -138,8 +147,12 @@ def user_images_identified(username):
 	# users can only view their own images
 	if user != current_user:
 		abort(403)
-	images = Image.query.filter_by(owner=user , identified=True)\
-		.order_by(Image.date_uploaded.desc()).all()
+
+	# get page, and paginate images
+	page = request.args.get('page', 1, type=int)
+	images = Image.query.filter_by(owner=user, identified=True)\
+		.order_by(Image.date_uploaded.desc()).paginate(page=page, per_page=9)
+	
 	return render_template('user_images_identified.html', images=images, user=user)
 
 
@@ -149,8 +162,12 @@ def user_images_training(username):
 	# users can only view their own images
 	if user != current_user:
 		abort(403)
-	images = Image.query.filter_by(owner=user , submit_for_training=True)\
-		.order_by(Image.date_uploaded.desc()).all()
+
+	# get page, and paginate images
+	page = request.args.get('page', 1, type=int)
+	images = Image.query.filter_by(owner=user, submit_for_training=True)\
+		.order_by(Image.date_uploaded.desc()).paginate(page=page, per_page=9)
+
 	return render_template('user_images_training.html', images=images, user=user)
 
 


### PR DESCRIPTION
I was tired and forgot to make a new branch for the image pagination 😢 So this PR includes pagination for all image pages, modifications to the carousel to fix the ID bug (where all carousels had the same ID), and also some extra logic that makes it so single image posts don't needlessly render a carousel.